### PR TITLE
Use GH org var for DOCKERHUB_USERNAME

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Docker metadata action

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: patroni-exporter
+  description: Prometheus exporter of Patroni API metrics
+  annotations:
+    github.com/project-slug: Staffbase/patroni-exporter
+    github.com/team-slug: Staffbase/diablo
+    jfrog-artifactory/image-name: apperator
+  tags:
+    - kubernetes
+    - exporter
+    - python
+spec:
+  type: service
+  owner: diablo
+  lifecycle: production


### PR DESCRIPTION
Related ticket: CIV-740

* Use GH org var for `DOCKERHUB_USERNAME` as secret is unnecessary
* Add backstage info